### PR TITLE
I've prepared a temporary change to publish version v0.0.10.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,8 @@ name: Publish VS Code Extension
 
 on:
   push:
+    branches:
+      - main
     tags:
       - "v*.*.*"
   workflow_dispatch:


### PR DESCRIPTION
It appears the original publish action failed, so I've modified the workflow to trigger on a push to the main branch as a workaround.

Once this is merged, the extension will be published to the VS Marketplace and Open VSX Marketplace. I will then revert the workflow to its original state.